### PR TITLE
fix: http example

### DIFF
--- a/examples/httpserver/main.go
+++ b/examples/httpserver/main.go
@@ -15,7 +15,6 @@ func main() {
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("Hello, World!"))
-			w.WriteHeader(http.StatusOK)
 		}),
 	}
 


### PR DESCRIPTION
Remove the superfluous response.WriteHeader call.

https://pkg.go.dev/net/http#ResponseWriter:
> If [ResponseWriter.WriteHeader] has not yet been called, Write calls
> WriteHeader(http.StatusOK) before writing the data.